### PR TITLE
Use FitViewport in AbstractScreen?

### DIFF
--- a/src/main/java/seprhou/gui/AbstractScreen.java
+++ b/src/main/java/seprhou/gui/AbstractScreen.java
@@ -7,7 +7,6 @@ import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.viewport.FitViewport;
-import com.badlogic.gdx.utils.viewport.StretchViewport;
 import seprhou.logic.LogicConstants;
 
 /**
@@ -46,7 +45,7 @@ public abstract class AbstractScreen implements Screen
 		this.enableEscape = enableEscape;
 
 		// Create stage to draw everything with
-		this.stage = new Stage(new StretchViewport(SCREEN_WIDTH, SCREEN_HEIGHT));
+		this.stage = new Stage(new FitViewport(SCREEN_WIDTH, SCREEN_HEIGHT));
 	}
 
 	/** Returns the game which owns this screen */


### PR DESCRIPTION
I've updated the game to use libGDX 1.0

One of the changes in libGDX are the different viewports. At the moment I've used StretchViewport to keep the game how it was, but you can use FitViewport instead which causes black bars to appear on foreign sized monitors. What does everyone think?

(You should be able to switch to / checkout the "fit-viewport" branch to test this from git)
